### PR TITLE
Handle parser errors

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,3 +1,4 @@
+use crate::parser;
 use std::fmt;
 
 pub enum Node {
@@ -49,6 +50,7 @@ impl fmt::Display for Identifier {
 #[derive(Debug, PartialEq)]
 pub struct Program {
     pub statements: Vec<Statement>,
+    pub errors: Vec<parser::ParserError>,
 }
 
 impl fmt::Display for Program {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,7 +1,39 @@
 use crate::ast;
 use crate::lexer::Lexer;
 use crate::token::Token;
-use std::mem;
+use std::{fmt, mem};
+
+#[derive(Debug, PartialEq)]
+pub enum ParserError {
+    SyntaxError(ParserErrorMessage),
+    UnhandledToken(Token),
+}
+
+impl fmt::Display for ParserError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ParserError::UnhandledToken(token) => write!(f, "Unhandled token: `{}`", token),
+            ParserError::SyntaxError(error) => write!(
+                f,
+                "[Row: {}, Col: {}] {}",
+                error.row, error.col, error.message
+            ),
+        }
+    }
+}
+
+#[derive(Debug, Default, PartialEq)]
+pub struct ParserErrorMessage {
+    message: String,
+    row: usize,
+    col: usize,
+}
+
+impl fmt::Display for ParserErrorMessage {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{} on row {}, col {}", self.message, self.row, self.col)
+    }
+}
 
 #[derive(Debug)]
 pub struct Parser<'a> {
@@ -31,24 +63,39 @@ impl<'a> Parser<'a> {
 
     pub fn parse_program(&mut self) -> ast::Program {
         let mut statements: Vec<ast::Statement> = Vec::new();
+        let mut errors: Vec<ParserError> = Vec::new();
         while self.curr_token != Token::EndOfFile {
-            if let Some(statement) = self.parse_statement() {
-                statements.push(statement);
+            match self.parse_statement() {
+                Ok(statement) => statements.push(statement),
+                Err(error) => errors.push(error),
             }
             self.next_token();
         }
-        ast::Program { statements }
+        ast::Program { statements, errors }
     }
 
-    fn parse_statement(&mut self) -> Option<ast::Statement> {
+    fn parse_statement(&mut self) -> Result<ast::Statement, ParserError> {
         match self.curr_token {
             Token::Let => self.parse_let_statement(),
-            _ => None,
+            _ => Err(ParserError::UnhandledToken(self.curr_token.clone())),
         }
     }
 
-    fn parse_let_statement(&mut self) -> Option<ast::Statement> {
-        if let Token::Identifier(ident) = &self.peek_token {
+    fn parse_let_statement(&mut self) -> Result<ast::Statement, ParserError> {
+        self.next_token();
+        if let Token::Identifier(ident) = &self.curr_token {
+            if self.peek_token != Token::Assign {
+                return Err(ParserError::SyntaxError(ParserErrorMessage {
+                    message: format!(
+                        "Expected `{}` to follow `{}`, got `{}` instead",
+                        Token::Assign,
+                        Token::Let,
+                        self.peek_token
+                    ),
+                    col: self.lexer.col,
+                    row: self.lexer.row,
+                }));
+            }
             let statement = ast::LetStatement {
                 name: ast::Identifier(ident.to_string()),
             };
@@ -56,10 +103,17 @@ impl<'a> Parser<'a> {
             while self.curr_token != Token::Semicolon {
                 self.next_token();
             }
-            Some(ast::Statement::Let(statement))
+            Ok(ast::Statement::Let(statement))
         } else {
-            // Parser error: Expected identifier to follow LetStatement
-            None
+            Err(ParserError::SyntaxError(ParserErrorMessage {
+                message: format!(
+                    "Expected identifier to follow `{}`, got `{}` instead",
+                    Token::Let,
+                    self.peek_token
+                ),
+                row: self.lexer.row,
+                col: self.lexer.col,
+            }))
         }
     }
 }
@@ -71,11 +125,9 @@ mod tests {
 
     #[test]
     fn it_parses_let_statements() {
-        let input = r#"
-            let x = 5;
-            let y = 10;
-            let foobar = 838383;
-        "#;
+        let input = r#"let x = 5;
+let y = 10;
+let foobar = 838383;"#;
         let expected = vec!["let x = TODO;", "let y = TODO;", "let foobar = TODO;"].join("");
 
         let expected_len = input.trim().lines().count();
@@ -91,5 +143,31 @@ mod tests {
             expected_len
         );
         assert_eq!(program.to_string(), expected);
+    }
+
+    #[test]
+    fn it_handles_parser_errors() {
+        let input = r#"let x 5;
+let = 10;
+let 838383;"#;
+        let expected = vec![
+            "[Row: 1, Col: 8] Expected `=` to follow `let`, got `5` instead",
+            "Unhandled token: `5`",
+            "Unhandled token: `;`",
+            "[Row: 2, Col: 9] Expected identifier to follow `let`, got `10` instead",
+            "Unhandled token: `10`",
+            "Unhandled token: `;`",
+            "[Row: 3, Col: 12] Expected identifier to follow `let`, got `;` instead",
+            "Unhandled token: `;`",
+        ];
+        let lexer = Lexer::new(input);
+        let mut parser = Parser::new(lexer);
+        let program = parser.parse_program();
+
+        for (i, expect) in expected.iter().enumerate() {
+            assert_eq!(expect, &program.errors[i].to_string());
+        }
+
+        assert_eq!(program.statements.len(), 0);
     }
 }

--- a/src/token.rs
+++ b/src/token.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 
 pub type IntegerSize = i64;
+pub type IdentifierType = String;
 
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum Token {
@@ -8,7 +9,7 @@ pub enum Token {
     Illegal(char),
     EndOfFile,
 
-    Identifier(String),
+    Identifier(IdentifierType),
     Integer(IntegerSize),
     String(String),
     Boolean(bool),


### PR DESCRIPTION
- Update lexer to record row and col #
- Parameterize Token::Identifier variant
- Update test input strings to have realistic newlines at the expense of
  slightly uglier (subjective) multi-line strings in our unit tests