### PR TITLE
Fix an issue where the outer scope was being replaced with the function's inner env

### DIFF
--- a/examples/fibonacci.monkey
+++ b/examples/fibonacci.monkey
@@ -1,0 +1,11 @@
+let fib = fn(n) {
+    if (n <= 0) {
+        return 0;
+    };
+    if (n == 1) {
+        return 1;
+    }
+    return fib(n - 1) + fib(n - 2);
+}
+
+fib(25);


### PR DESCRIPTION
Previously the interpreter's outer env would be incorrectly set to the
function's inner env.

The stack overflow is not due to recursion but rather that the
function's local identifiers were incorrectly being set as a result.
This would cause the local to indefinitely decrement in a loop, which
was not hitting the base case in the original fibonacci implementation.

Closes #45